### PR TITLE
[in1Utils] Fix generateTopo.py

### DIFF
--- a/debrisframe/in1Utils/generateTopo.py
+++ b/debrisframe/in1Utils/generateTopo.py
@@ -45,9 +45,10 @@ def debrisFlowTopoAverage(cfg):
     [A, B, fLen] = genTop.getParabolaParams(cfg)
 
     # Set surface elevation
+    zv = np.ones((nRows, nCols))
     mask = np.zeros(np.shape(xv))
     mask[np.where(xv < fLen)] = 1 
-    zv = (A * xv ** 2 + B * xv + C) * mask
+    zv = zv * (A * xv ** 2 + B * xv + C) * mask
 
     # If a channel shall be introduced
     if cfg["TOPO"].getboolean("channel"):

--- a/debrisframe/in1Utils/generateTopoCfg.ini
+++ b/debrisframe/in1Utils/generateTopoCfg.ini
@@ -34,6 +34,9 @@ meanAlpha = 0
 # total fall height [m] - required for PF, HX, DFTA
 C = 709
 
+# flag to set channel
+channel = True
+
 #------------------------------------------------------
 
 # Channel parameters -----------------------------------


### PR DESCRIPTION
Fix `in1Utils/generateTopo.py` to allow the generation of generic debris-flow topographies without any channels.
Before, when `channel` was `False` in `generateTopoCfg.ini` an error concering the shape of `zv` occured.